### PR TITLE
Update visualization.yaml

### DIFF
--- a/visualization.yaml
+++ b/visualization.yaml
@@ -15,6 +15,7 @@ services:
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3000/healthz']
       interval: 1s
+      start_period: 5s
       start_interval: 0s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
 ✘ Container grafana               healthcheck.start_interval requires healthcheck.start_period to be set